### PR TITLE
Test CI Pipeline Dependencies

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -27,7 +27,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install coverage pytest pytest-cov
+        pip install --upgrade pip setuptools wheel
+        pip install -e ".[dev]"
 
     - name: Run tests with coverage
       run: |
@@ -48,6 +49,16 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip setuptools wheel
+        pip install -e ".[dev]"
 
     - name: Run CodeClimate
       uses: paambaati/codeclimate-action@v9.0.0

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install formatters
       run: |
         # Python formatters
-        pip install black isort
+        pip install -e ".[dev]"
         
         # Lua formatter with error handling
         wget --retry-connrefused --tries=3 https://github.com/JohnnyMorganz/StyLua/releases/download/v0.20.0/stylua-linux.zip
@@ -116,8 +116,7 @@ jobs:
       run: |
         case "${{ matrix.language }}" in
           python)
-            pip install flake8 mypy pylint bandit safety
-            pip install -r jimbot/infrastructure/requirements.txt
+            pip install -e ".[dev]"
             ;;
           lua)
             sudo apt-get update
@@ -183,8 +182,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip setuptools wheel
-        pip install -r jimbot/infrastructure/requirements.txt
-        pip install pytest pytest-cov pytest-asyncio pytest-benchmark pytest-timeout
+        pip install -e ".[dev,test]"
         if [ -f "jimbot/${{ matrix.component }}/requirements.txt" ]; then
           pip install -r jimbot/${{ matrix.component }}/requirements.txt
         fi
@@ -235,8 +233,8 @@ jobs:
 
     - name: Run integration tests
       run: |
-        pip install -r jimbot/infrastructure/requirements.txt
-        pip install pytest pytest-asyncio pytest-timeout requests
+        pip install -e ".[dev,test]"
+        pip install requests
         
         pytest jimbot/tests/integration/ \
           -v \
@@ -280,7 +278,10 @@ jobs:
         source venv-gpu/bin/activate
         pip install --upgrade pip
         pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
-        pip install -r jimbot/training/requirements.txt
+        pip install -e ".[dev,test]"
+        if [ -f "jimbot/training/requirements.txt" ]; then
+          pip install -r jimbot/training/requirements.txt
+        fi
 
     - name: Verify GPU availability
       run: |
@@ -382,8 +383,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -r jimbot/infrastructure/requirements.txt
-        pip install pytest pytest-benchmark
+        pip install -e ".[dev,test]"
 
     - name: Run benchmarks
       run: |
@@ -420,7 +420,7 @@ jobs:
 
     - name: Install documentation tools
       run: |
-        pip install sphinx sphinx-rtd-theme myst-parser autodoc
+        pip install -e ".[docs]"
 
     - name: Build documentation
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Thumbs.db
 
 # Process files
 *.pidtest_env/
+test_env/

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,5 @@ htmlcov/
 Thumbs.db
 
 # Process files
-*.pidtest_env/
+*.pid
 test_env/

--- a/scripts/test_dependencies.py
+++ b/scripts/test_dependencies.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+Test script to verify that all testing dependencies can be imported.
+This helps validate that pyproject.toml properly declares all dependencies.
+"""
+
+import sys
+import importlib
+
+# List of modules that should be available when dev dependencies are installed
+TEST_MODULES = [
+    "pytest",
+    "pytest_asyncio",
+    "pytest_cov", 
+    "pytest_mock",
+    "pytest_timeout",
+    "pytest_benchmark",
+    "pytest_xdist",
+    "coverage",
+    "hypothesis",
+    "black",
+    "isort", 
+    "ruff",
+    "flake8",
+    "mypy",
+    "pylint",
+    "pydocstyle",
+    "bandit",
+    "safety",
+]
+
+def test_import(module_name):
+    """Try to import a module and return success status."""
+    try:
+        importlib.import_module(module_name)
+        print(f"✓ {module_name}")
+        return True
+    except ImportError as e:
+        print(f"✗ {module_name}: {e}")
+        return False
+
+def main():
+    """Test all required imports."""
+    print("Testing dev dependency imports...\n")
+    
+    failures = []
+    for module in TEST_MODULES:
+        if not test_import(module):
+            failures.append(module)
+    
+    print(f"\nSummary: {len(TEST_MODULES) - len(failures)}/{len(TEST_MODULES)} modules imported successfully")
+    
+    if failures:
+        print(f"\nFailed imports: {', '.join(failures)}")
+        print("\nTo fix, run: pip install -e '.[dev]'")
+        sys.exit(1)
+    else:
+        print("\nAll dev dependencies are properly installed!")
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_ci.py
+++ b/scripts/validate_ci.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""
+Validation script to test CI pipeline configuration.
+This is a minimal change to trigger CI without affecting functionality.
+"""
+
+def main():
+    """Simple validation to ensure CI runs."""
+    print("CI Pipeline Validation")
+    print("=" * 50)
+    print("Testing that all CI workflows properly install dependencies")
+    print("using 'pip install -e \".[dev]\"' pattern")
+    print("=" * 50)
+    print("✓ This script exists to trigger CI pipeline")
+    print("✓ No functional changes to the codebase")
+    return 0
+
+if __name__ == "__main__":
+    exit(main())


### PR DESCRIPTION
Testing that CI pipelines work correctly with the new 'pip install -e ".[dev]"' pattern from PR #118.

This PR adds a minimal validation script that should trigger all CI workflows to verify:
- Dependencies are properly installed
- All formatters, linters, and test tools are available
- No missing package errors occur

This is a test PR that can be closed once CI passes.