### PR TITLE
Fix Rust CI Workflow Failing (#122)

### DIFF
--- a/.github/workflows/rust-basic.yml
+++ b/.github/workflows/rust-basic.yml
@@ -3,16 +3,61 @@ name: Rust Basic CI
 on:
   push:
     branches: [main]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '**/*.rs'
+      - '.github/workflows/rust-basic.yml'
   pull_request:
     branches: [main]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '**/*.rs'
+      - '.github/workflows/rust-basic.yml'
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  detect-rust:
+    name: Detect Rust Code
+    runs-on: ubuntu-latest
+    outputs:
+      has-rust: ${{ steps.detect.outputs.has-rust }}
+      rust-dirs: ${{ steps.detect.outputs.rust-dirs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Detect Rust components
+        id: detect
+        run: |
+          # Find all Cargo.toml files (excluding target directories and node_modules)
+          RUST_DIRS=$(find . -name "Cargo.toml" -not -path "./target/*" -not -path "*/target/*" -not -path "./node_modules/*" -not -path "*/node_modules/*" | while read -r cargo_file; do
+            dirname "$cargo_file"
+          done | sort -u)
+          
+          if [ -n "$RUST_DIRS" ]; then
+            echo "has-rust=true" >> $GITHUB_OUTPUT
+            # Convert to JSON array for matrix
+            RUST_DIRS_JSON=$(echo "$RUST_DIRS" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            echo "rust-dirs=$RUST_DIRS_JSON" >> $GITHUB_OUTPUT
+            echo "Found Rust directories: $RUST_DIRS"
+          else
+            echo "has-rust=false" >> $GITHUB_OUTPUT
+            echo "rust-dirs=[]" >> $GITHUB_OUTPUT
+            echo "No Rust code found in repository"
+          fi
+
   check:
     name: Rust CI
     runs-on: ubuntu-latest
+    needs: detect-rust
+    if: needs.detect-rust.outputs.has-rust == 'true'
+    strategy:
+      matrix:
+        rust-dir: ${{ fromJson(needs.detect-rust.outputs.rust-dirs) }}
 
     steps:
       - name: Checkout repository
@@ -26,16 +71,21 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
+          workspaces: ${{ matrix.rust-dir }}
           cache-on-failure: true
 
       - name: Check formatting
+        working-directory: ${{ matrix.rust-dir }}
         run: cargo fmt --all -- --check
 
       - name: Run Clippy lints
+        working-directory: ${{ matrix.rust-dir }}
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run tests
+        working-directory: ${{ matrix.rust-dir }}
         run: cargo test --all-features --workspace
 
       - name: Check for build warnings
+        working-directory: ${{ matrix.rust-dir }}
         run: cargo check --all-targets --all-features


### PR DESCRIPTION
## Summary
Fixed the Rust Basic CI workflow that was failing in 17-23 seconds by making it conditional on the presence of Rust code in the repository.

## Changes Made
- **Path Filters**: Added path filters to only trigger the workflow when Rust-related files change
- **Detection Job**: Added a `detect-rust` job that finds all Cargo.toml files and identifies Rust directories
- **Conditional Execution**: Made the CI job conditional using `if: needs.detect-rust.outputs.has-rust == 'true'`
- **Matrix Strategy**: Used matrix strategy to handle multiple Rust directories
- **Working Directory**: Set the correct working directory for cargo commands

## Problem Fixed
The original workflow was failing because it was trying to run `cargo` commands from the root directory, but the Rust code is located in `services/event-bus-rust/`. This workflow now:
1. Detects where Rust code exists in the repository
2. Only runs if Rust code is found
3. Runs cargo commands from the correct working directory

## Test Plan
- [x] Workflow should now pass on this PR
- [x] Workflow should properly detect the `services/event-bus-rust` directory
- [x] Workflow should run cargo commands from the correct working directory
- [x] Workflow should skip gracefully if no Rust code exists

## Technical Context
This fix aligns the `rust-basic.yml` workflow with the patterns used in `rust-ci-cd.yml` and `rust-security.yml`, which already have proper conditional logic.

Fixes #122

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>