### PR TITLE
refactor: Rename BalatroGymEnv to JimGymEnv

### DIFF
--- a/balatro_rust_emulator_spec.md
+++ b/balatro_rust_emulator_spec.md
@@ -549,7 +549,7 @@ import ray
 from ray import tune
 from ray.rllib.agents.ppo import PPOTrainer
 
-class BalatroGymEnv(gym.Env):
+class JimGymEnv(gym.Env):
     def __init__(self, config):
         self.emulator = BalatroEnv(
             deck=config.get("deck", "Red"),


### PR DESCRIPTION
## Summary
This PR implements the rename from `BalatroGymEnv` to `JimGymEnv` as requested in issue #186. The new name is a clever play on words combining 'Jim' (from Jimbot) with 'Gym' (from the reinforcement learning environment).

## Changes
- ✅ Renamed `BalatroGymEnv` class to `JimGymEnv` in `balatro_rust_emulator_spec.md`

## Scope of Search
A comprehensive search was performed across the entire codebase:
- Searched for: `BalatroGym`, `balatrogym`, `BALATROGYM`
- Found only one reference in the specification document
- No module names, imports, or external references needed updating

## Testing
This is a documentation-only change in the Rust emulator specification. No code execution or tests are affected by this rename.

## Notes
The rename maintains the connection to both the Jimbot project and the OpenAI Gym interface while adding a memorable wordplay element to the project.

Closes #186