### PR TITLE
Fix: memgraph authentication configuration in docker-compose.ci.yml

### DIFF
--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -95,9 +95,6 @@ services:
     ports:
       - "7687:7687"
       - "3000:3000"
-    environment:
-      MEMGRAPH_USER: ""
-      MEMGRAPH_PASSWORD: ""
     healthcheck:
       # Check Memgraph Lab HTTP endpoint - most reliable method that doesn't require mgconsole
       # The Memgraph Docker image includes curl, making this a simple and effective health check


### PR DESCRIPTION
Closes #195

## Summary
- Fixed memgraph authentication configuration in `docker-compose.ci.yml` by removing empty `MEMGRAPH_USER` and `MEMGRAPH_PASSWORD` environment variables
- These empty environment variables were causing "Invalid user name" errors and container restart loops
- Memgraph Community Edition runs without authentication by default when these variables are not set

## Changes Made
- Removed empty `MEMGRAPH_USER: ""` and `MEMGRAPH_PASSWORD: ""` from memgraph service configuration
- This allows memgraph to use its default behavior (no authentication required)

## Testing
- Validated docker-compose syntax with `docker-compose config`
- Confirmed that memgraph service configuration is now clean and follows defaults

## Impact
- Resolves container restart loops in CI environment
- Allows CI tests to connect to memgraph successfully
- Eliminates "Invalid user name" authentication errors
- No changes to functionality - memgraph remains accessible to CI services

🤖 Generated with [Claude Code](https://claude.ai/code)