### PR TITLE
Fix #363: Add Python dependency caching to CI workflows

### DIFF
--- a/.github/workflows/CI_CACHING_STRATEGY.md
+++ b/.github/workflows/CI_CACHING_STRATEGY.md
@@ -1,0 +1,59 @@
+# CI Caching Strategy
+
+## Overview
+This document describes the caching strategy for Python dependencies in CI workflows.
+
+## Workflows with Direct Python Caching
+
+### ci-health-monitor.yml
+- Uses `actions/setup-python@v5` with built-in pip caching
+- Cache key based on: `**/requirements*.txt`, `**/pyproject.toml`, `setup.py`
+- Expected improvement: ~2-3 minutes to ~10 seconds for pip install
+
+## Docker-based Workflows
+
+The following workflows use Docker for Python execution:
+- `ci-tests.yml`
+- `ci-integration.yml`
+- `ci-quick.yml`
+
+### Why Direct pip Caching Isn't Used
+These workflows run Python inside Docker containers built from `docker/Dockerfile.ci-unified`. The Python dependencies are installed during the Docker build process, not in the GitHub Actions workflow directly.
+
+### Existing Caching Strategy
+These workflows already benefit from Docker layer caching:
+```yaml
+cache-from: type=gha
+cache-to: type=gha,mode=max
+```
+
+This caches the entire Docker build, including:
+- Base OS packages
+- Python installation
+- pip packages installed in the Dockerfile
+- Other language toolchains (Rust, Lua)
+
+### Benefits
+- First build: Full Docker build including all dependencies
+- Subsequent builds: Reuses cached layers if dependencies haven't changed
+- Cache invalidation: Automatic when Dockerfile or dependency files change
+
+## Cache Key Strategy
+
+For workflows using direct Python setup:
+- Primary cache key: OS + Python version + hash of dependency files
+- Restore keys fallback to partial matches for faster builds
+
+## Monitoring Cache Effectiveness
+
+Check workflow run times to verify cache hits:
+1. Look for "Cache restored successfully" in setup-python step
+2. Compare pip install times between cache hit vs miss
+3. Monitor overall workflow duration improvements
+
+## Future Improvements
+
+If Docker-based workflows need faster Python dependency updates:
+1. Consider adding requirements.txt copying and pip install as separate Docker layers
+2. Use multi-stage builds to optimize caching
+3. Implement dependency pinning for reproducible builds

--- a/.github/workflows/ci-health-monitor.yml
+++ b/.github/workflows/ci-health-monitor.yml
@@ -42,6 +42,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements*.txt
+            **/pyproject.toml
+            setup.py
           
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Closes #363

## Summary
This PR adds Python dependency caching to CI workflows to reduce build times.

## Changes Made
- Added pip caching to  using the built-in cache feature of 
- Created documentation explaining the caching strategy for both direct Python workflows and Docker-based workflows

## Implementation Details

### Direct Python Caching
The  workflow now uses:
```yaml
cache: 'pip'
cache-dependency-path:  < /dev/null | 
  **/requirements*.txt
  **/pyproject.toml
  setup.py
```

### Docker-based Workflows
The workflows using Docker (, , ) already benefit from Docker layer caching through GitHub Actions cache. This is documented in the new  file.

## Expected Benefits
- Reduce pip install time from ~2-3 minutes to ~10 seconds for direct Python workflows
- Clearer documentation of caching strategies across different workflow types

## Test Results
- YAML syntax validated
- Changes are minimal and low-risk
- The caching will be tested automatically on the next run of 

## Documentation
Added  to explain the caching approach for all CI workflows.