### PR TITLE
fix: increase CI quick checks timeout from 10 to 20 minutes

### DIFF
--- a/.github/workflows/ci-quick.yml
+++ b/.github/workflows/ci-quick.yml
@@ -11,7 +11,7 @@ jobs:
   quick-checks:
     name: Format and Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Increased timeout for CI quick checks workflow from 10 to 20 minutes

## Problem
The quick checks workflow was occasionally timing out at 10 minutes during Docker image building and linting steps, causing unnecessary CI failures.

## Solution
Increased the timeout to 20 minutes to provide adequate buffer time for:
- Docker image building with dependencies
- Python format checking (black, isort)
- Python linting (flake8, pylint, mypy)
- Rust format checking (cargo fmt)
- Rust linting (cargo clippy)
- Security audit (cargo audit)

## Test plan
- [x] CI quick checks workflow should complete within 20 minutes
- [x] No functional changes, only timeout adjustment
- [x] Backwards compatible change

🤖 Generated with [Claude Code](https://claude.ai/code)